### PR TITLE
Feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [1.0.0-beta.28](https://github.com/troy213/expense-tracker-v2/compare/v1.0.0-beta.27...v1.0.0-beta.28) (2026-06-02)
+
+
+### Features
+
+* **app:** gate rendering behind isInitialized with a loading spinner ([58d53b1](https://github.com/troy213/expense-tracker-v2/commit/58d53b1bf7da14559386c44752ca61fc80a78dd4))
+* **config:** add isInitialized flag and setInitialized reducer ([b91c127](https://github.com/troy213/expense-tracker-v2/commit/b91c1275d078a8aced5fd63d6937a727f5542fef))
+* **init:** await all bootstrap loads before marking initialized ([dd76022](https://github.com/troy213/expense-tracker-v2/commit/dd7602248ec1bcd1922627b9dee9676ef595da75))
+
 ## [1.0.0-beta.27](https://github.com/troy213/expense-tracker-v2/compare/v1.0.0-beta.26...v1.0.0-beta.27) (2026-06-01)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "expense-tracker-v2",
-  "version": "1.0.0-beta.27",
+  "version": "1.0.0-beta.28",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "expense-tracker-v2",
-      "version": "1.0.0-beta.27",
+      "version": "1.0.0-beta.28",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "expense-tracker-v2",
   "private": true,
-  "version": "1.0.0-beta.27",
+  "version": "1.0.0-beta.28",
   "type": "module",
   "scripts": {
     "dev": "vite --host --open --port 3000",

--- a/src/App.scss
+++ b/src/App.scss
@@ -1,0 +1,9 @@
+@import '@/styles/variables';
+
+.app-loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100dvh;
+  background-color: $color-primary;
+}

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { describe, it, expect } from 'vitest'
 import { Provider } from 'react-redux'
 import { MemoryRouter } from 'react-router-dom'
@@ -7,7 +7,7 @@ import store from '@/store'
 import App from './App'
 
 describe('App Component routing test', () => {
-  it('renders the Dashboard component on the root path', () => {
+  it('renders the Dashboard component on the root path', async () => {
     render(
       <MemoryRouter initialEntries={['/']}>
         <Provider store={store}>
@@ -16,10 +16,10 @@ describe('App Component routing test', () => {
       </MemoryRouter>
     )
 
-    expect(screen.getByText('Dashboard')).toBeInTheDocument()
+    expect(await screen.findByText('Dashboard')).toBeInTheDocument()
   })
 
-  it('renders the Categories component on /categories path', () => {
+  it('renders the Categories component on /categories path', async () => {
     render(
       <MemoryRouter initialEntries={['/categories']}>
         <Provider store={store}>
@@ -28,10 +28,10 @@ describe('App Component routing test', () => {
       </MemoryRouter>
     )
 
-    expect(screen.getByText('Category & Budget')).toBeInTheDocument()
+    expect(await screen.findByText('Category & Budget')).toBeInTheDocument()
   })
 
-  it('renders the Reports component on /reports path', () => {
+  it('renders the Reports component on /reports path', async () => {
     render(
       <MemoryRouter initialEntries={['/reports']}>
         <Provider store={store}>
@@ -40,10 +40,10 @@ describe('App Component routing test', () => {
       </MemoryRouter>
     )
 
-    expect(screen.getByText('Reports')).toBeInTheDocument()
+    expect(await screen.findByText('Reports')).toBeInTheDocument()
   })
 
-  it('renders the Report Detail component on /report-detail path', () => {
+  it('renders the Report Detail component on /report-detail path', async () => {
     render(
       <MemoryRouter initialEntries={['/report-detail?type=expense']}>
         <Provider store={store}>
@@ -52,10 +52,13 @@ describe('App Component routing test', () => {
       </MemoryRouter>
     )
 
-    expect(screen.getByText('Reports')).toBeInTheDocument()
+    // ReportDetail swaps its Navbar between the loading and loaded render trees,
+    // so re-query the live DOM (waitFor + getByText) rather than holding a node
+    // that may unmount mid-flight (findByText).
+    await waitFor(() => expect(screen.getByText('Reports')).toBeInTheDocument())
   })
 
-  it('renders the Settings component on /settings path', () => {
+  it('renders the Settings component on /settings path', async () => {
     render(
       <MemoryRouter initialEntries={['/settings']}>
         <Provider store={store}>
@@ -64,10 +67,10 @@ describe('App Component routing test', () => {
       </MemoryRouter>
     )
 
-    expect(screen.getByText('Settings')).toBeInTheDocument()
+    expect(await screen.findByText('Settings')).toBeInTheDocument()
   })
 
-  it('renders the Theme component on /settings/theme path', () => {
+  it('renders the Theme component on /settings/theme path', async () => {
     render(
       <MemoryRouter initialEntries={['/settings/theme']}>
         <Provider store={store}>
@@ -76,10 +79,10 @@ describe('App Component routing test', () => {
       </MemoryRouter>
     )
 
-    expect(screen.getByText('Theme')).toBeInTheDocument()
+    expect(await screen.findByText('Theme')).toBeInTheDocument()
   })
 
-  it('renders the Languages component on /settings/language path', () => {
+  it('renders the Languages component on /settings/language path', async () => {
     render(
       <MemoryRouter initialEntries={['/settings/language']}>
         <Provider store={store}>
@@ -88,10 +91,10 @@ describe('App Component routing test', () => {
       </MemoryRouter>
     )
 
-    expect(screen.getByText('Language')).toBeInTheDocument()
+    expect(await screen.findByText('Language')).toBeInTheDocument()
   })
 
-  it('renders the NotFound component on an unknown path', () => {
+  it('renders the NotFound component on an unknown path', async () => {
     render(
       <MemoryRouter initialEntries={['/unknown-path']}>
         <Provider store={store}>
@@ -100,6 +103,6 @@ describe('App Component routing test', () => {
       </MemoryRouter>
     )
 
-    expect(screen.getByText('Page Not Found')).toBeInTheDocument()
+    expect(await screen.findByText('Page Not Found')).toBeInTheDocument()
   })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,8 @@ import { useEffect } from 'react'
 import { Layout, PWAInstallPrompt } from '@/components'
 import { LANGUAGES, LOCALES, THEME } from '@/constants'
 import { useAppSelector, useInitConfig } from '@/hooks'
+import { SpinnerSvg } from '@/assets'
+import './App.scss'
 import {
   Categories,
   Dashboard,
@@ -21,7 +23,9 @@ import {
 } from '@/pages/Settings'
 
 const App = () => {
-  const { locale, theme } = useAppSelector((state) => state.configReducer)
+  const { locale, theme, isInitialized } = useAppSelector(
+    (state) => state.configReducer
+  )
   const currentLanguage = LANGUAGES[locale] || LANGUAGES[LOCALES.ENGLISH]
 
   useInitConfig()
@@ -33,6 +37,14 @@ const App = () => {
       document.body.classList.remove(THEME.DARK)
     }
   }, [theme])
+
+  if (!isInitialized) {
+    return (
+      <div className="app-loading">
+        <SpinnerSvg className="icon--2xl icon--fill-white spin" />
+      </div>
+    )
+  }
 
   return (
     <IntlProvider

--- a/src/hooks/useInitConfig.ts
+++ b/src/hooks/useInitConfig.ts
@@ -2,6 +2,9 @@ import { useEffect } from 'react'
 import dbServices from '@/lib/db'
 import { getAllDBTransactions } from '@/store/transactions/transactions-thunk'
 import { getAllDBCategories } from '@/store/categories/categories-thunk'
+import { getDBDashboardInfo } from '@/store/main/main-thunk'
+import { getDBReportData } from '@/store/report/report-thunk'
+import { configAction } from '@/store/config/config-slice'
 import useAppDispatch from './useAppDispatch'
 
 const useInitConfig = () => {
@@ -9,14 +12,22 @@ const useInitConfig = () => {
 
   useEffect(() => {
     const initializeData = async () => {
-      // Initialize IndexedDB
+      // Initialize IndexedDB before any store reads it.
       await dbServices.initializeDB()
 
-      // Load categories from IndexedDB or migrate from localStorage
-      dispatch(getAllDBCategories())
+      // Load base data + derived dashboard/report in parallel. The derived
+      // thunks read IndexedDB directly, so they don't depend on the base loads.
+      // Awaiting all four guarantees every reducer is populated before we open
+      // the render gate (no cold-start flash).
+      await Promise.all([
+        dispatch(getAllDBCategories()),
+        dispatch(getAllDBTransactions()),
+        dispatch(getDBDashboardInfo()),
+        dispatch(getDBReportData({ dateFrom: null, dateTo: null })),
+      ])
 
-      // Load transactions from IndexedDB or migrate from localStorage
-      dispatch(getAllDBTransactions())
+      // Open the render gate.
+      dispatch(configAction.setInitialized(true))
     }
 
     initializeData()

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -49,11 +49,27 @@ vi.mock('@/lib/db', () => ({
         total: 0,
       }),
       getTransactionById: vi.fn().mockResolvedValue(undefined),
+      getFilteredTransactions: vi.fn().mockResolvedValue([]),
       putTransaction: vi.fn().mockResolvedValue(''),
       putTransactions: vi.fn().mockResolvedValue(undefined),
       deleteTransaction: vi.fn().mockResolvedValue(undefined),
       deleteTransactions: vi.fn().mockResolvedValue(undefined),
       clearTransactions: vi.fn().mockResolvedValue(undefined),
+    },
+    report: {
+      getDashboardInfo: vi.fn().mockResolvedValue({
+        totalIncome: 0,
+        totalExpense: 0,
+        totalBudget: 0,
+        remainingBudget: 0,
+      }),
+      getReportData: vi.fn().mockResolvedValue({
+        totalIncome: 0,
+        totalExpense: 0,
+        avgSpending: 0,
+        incomeReport: [],
+        expenseReport: [],
+      }),
     },
   },
 }))

--- a/src/store/config/config-slice.test.ts
+++ b/src/store/config/config-slice.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import configSlice, { configAction } from './config-slice'
+
+describe('configSlice — isInitialized', () => {
+  it('defaults isInitialized to false', () => {
+    const state = configSlice.reducer(undefined, { type: '@@INIT' })
+    expect(state.isInitialized).toBe(false)
+  })
+
+  it('setInitialized sets the flag to the payload value', () => {
+    const next = configSlice.reducer(
+      undefined,
+      configAction.setInitialized(true)
+    )
+    expect(next.isInitialized).toBe(true)
+
+    const back = configSlice.reducer(next, configAction.setInitialized(false))
+    expect(back.isInitialized).toBe(false)
+  })
+})

--- a/src/store/config/config-slice.ts
+++ b/src/store/config/config-slice.ts
@@ -7,12 +7,14 @@ export type InitialState = {
   theme: Theme
   locale: Locales
   hideBalance: boolean
+  isInitialized: boolean
 }
 
 const initialState: InitialState = {
   theme: (getStorage('theme') as Theme) ?? THEME.LIGHT,
   locale: (getStorage('locales') as Locales) ?? LOCALES.ENGLISH,
   hideBalance: getStorageConfig()?.hideBalance ?? false,
+  isInitialized: false,
 }
 
 const configSlice = createSlice({
@@ -36,6 +38,11 @@ const configSlice = createSlice({
     setHideBalanceDefault(state, action: PayloadAction<boolean>) {
       state.hideBalance = action.payload
       setStorage('config', JSON.stringify({ hideBalance: action.payload }))
+    },
+    // App-level bootstrap gate. Set true once useInitConfig finishes loading.
+    // Not persisted.
+    setInitialized(state, action: PayloadAction<boolean>) {
+      state.isInitialized = action.payload
     },
   },
 })


### PR DESCRIPTION
## Summary
Gates all app rendering behind an `isInitialized` flag so the bootstrap thunks
fire ~2× instead of ~4× on first load, and the cold-start zero/empty flash is
removed.

- `useInitConfig` awaits all four loads in parallel, then flips `isInitialized`.
- `App` shows a spinner until initialized, then renders the routes.
- Page components/effects unchanged — pages no longer mount mid-stream, so the
  redundant refires disappear; data stays fresh on remount.

## Commits
- feat(config): add isInitialized flag and setInitialized reducer
- feat(init): await all bootstrap loads before marking initialized
- feat(app): gate rendering behind isInitialized with a loading spinner

## Testing
- `npm run test` → 59/59 pass (incl. new config-slice test + updated App tests)
- `npm run lint` → zero warnings
- `npm run build` → succeeds

## Notes
Merge with a **merge commit** (not squash) so the `v1.0.0-beta.28` tag stays
reachable on main.
